### PR TITLE
Remove the imu_compass dependency

### DIFF
--- a/heron_base/package.xml
+++ b/heron_base/package.xml
@@ -26,7 +26,6 @@
   <run_depend>rosserial_server</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>um6</run_depend>
-  <run_depend>imu_compass</run_depend>
   <run_depend>heron_control</run_depend>
   <run_depend>wireless_watcher</run_depend>
   <run_depend>imu_filter_madgwick</run_depend>


### PR DESCRIPTION
The package is listed as a run_depend, but no nodes or launch files from it appear to be used anywhere within heron_base
imu_compass has not been released for Melodic, so if we can remove it as a dependency safely that will remove one of the last blockers for Melodic support.