### PR TITLE
Allow disabling the magnetometer input to the IMU filter

### DIFF
--- a/heron_base/launch/base.launch
+++ b/heron_base/launch/base.launch
@@ -1,6 +1,9 @@
 <launch>
   <arg name="namespace" value="$(optenv ROBOT_NAMESPACE)" />
 
+  <!-- If the IMU does not publish magnetometer data, this should be set to false -->
+  <arg name="use_mag"   default="$(optenv HERON_MAGNETOMETER_ENABLED true)" />
+
   <include file="$(find heron_description)/launch/description.launch">
     <arg name="namespace" value="$(arg namespace)" />
   </include>
@@ -50,6 +53,7 @@
 
     <node pkg="imu_filter_madgwick" type="imu_filter_node" name="imu_filter_madgwick">
       <rosparam file="$(env HERON_MAG_CONFIG)" />
+      <param name="~use_mag" value="$(arg use_mag)" />
       <param name="~use_magnetic_field_msg" value="false" />
       <param name="world_frame" value="enu" />
       <param name="publish_tf" value="false" />


### PR DESCRIPTION
Add an env var to disable the magnetometer input to the IMU filter, for instances where the IMU does not support that.

This is a rare use-case, since herons _should_ ship standard with a mag-capable IMU.  But in the rare cases where it's either damaged or missing the IMU filter will not publish to /imu/data, which in turn prevents commands to /cmd_vel from being processed.