### PR TITLE
Replace now-defunct UM6 as default, use CV5-25 instead, as-per RPSW-661

### DIFF
--- a/heron_base/launch/base.launch
+++ b/heron_base/launch/base.launch
@@ -28,14 +28,25 @@
 
     <group unless="$(optenv HERON_IMU_UM6 0)">
       <!-- newer herons use the microstrain CM5-25 IMU -->
-      <include filename="$(find ros_mscl)/launch/microstrain.launch">
-        <arg name="name"          value="cv5" />
-        <arg name="port"          value="$(optenv HERON_IMU_PORT /dev/microstrain)" /> <!-- TODO - verify the correct default -->
-        <arg name="imu_frame_id"  value="imu_link" />
-        <!-- TODO - double-check topic names -->
-        <remap from="cv5/data"    to="imu/raw_raw" />
-        <remap from="cv5/mag"     to="imu/mag" />
-      </include>
+      <group if="$(eval arg('namespace') == '')">
+        <include filename="$(find ros_mscl)/launch/microstrain.launch">
+          <arg name="name"          value="cv5" />
+          <arg name="port"          value="$(optenv HERON_IMU_PORT /dev/microstrain)" />
+          <arg name="imu_frame_id"  value="imu_link" />
+          <remap from="cv5/data"    to="imu/raw_raw" />
+          <remap from="cv5/mag"     to="imu/mag" />
+        </include>
+      </group>
+
+      <group unless="$(eval arg('namespace') == '')">
+        <include filename="$(find ros_mscl)/launch/microstrain.launch">
+          <arg name="name"          value="cv5" />
+          <arg name="port"          value="$(optenv HERON_IMU_PORT /dev/microstrain)" />
+          <arg name="imu_frame_id"  value="$(arg namespace)/imu_link" />
+          <remap from="cv5/data"    to="imu/raw_raw" />
+          <remap from="cv5/mag"     to="imu/mag" />
+        </include>
+      </group>
     </group>
     <group if="$(optenv HERON_IMU_UM6 0)">
       <!-- older herons use the UM6 IMU -->

--- a/heron_base/launch/base.launch
+++ b/heron_base/launch/base.launch
@@ -26,28 +26,6 @@
         <node ns="wireless" pkg="wireless_watcher" name="wireless_watcher" type="watcher_node" respawn="true" />
     </group>
 
-    <group if="$(eval arg('namespace') == '')">
-     <node pkg="um6" type="um6_driver" name="um6_driver" output="screen">
-       <param name="tf_ned_to_enu" value="true"/>
-       <param name="/um6_driver/port" value="$(optenv HERON_IMU_UM6_PORT /dev/clearpath/imu)" />
-       <remap from="imu/data" to="imu/data_raw" />
-       <param name="lt_model" value="true" />
-       <param name="linear_acceleration_stdev" value="0.38" />
-       <param name="frame_id" value="imu_link" />
-     </node>
-    </group>
-
-    <group unless="$(eval arg('namespace') == '')">
-     <node pkg="um6" type="um6_driver" name="um6_driver" output="screen">
-       <param name="tf_ned_to_enu" value="true"/>
-       <param name="/um6_driver/port" value="$(optenv HERON_IMU_UM6_PORT /dev/clearpath/imu)" />
-       <remap from="imu/data" to="imu/data_raw" />
-       <param name="lt_model" value="true" />
-       <param name="linear_acceleration_stdev" value="0.38" />
-       <param name="frame_id" value="$(arg namespace)/imu_link" />
-     </node>
-    </group>
-
     <node pkg="imu_filter_madgwick" type="imu_filter_node" name="imu_filter_madgwick">
       <rosparam file="$(env HERON_MAG_CONFIG)" />
       <param name="~use_magnetic_field_msg" value="false" />

--- a/heron_base/launch/base.launch
+++ b/heron_base/launch/base.launch
@@ -26,6 +26,42 @@
         <node ns="wireless" pkg="wireless_watcher" name="wireless_watcher" type="watcher_node" respawn="true" />
     </group>
 
+    <group unless="$(optenv HERON_IMU_UM6 0)">
+      <!-- newer herons use the microstrain CM5-25 IMU -->
+      <include filename="$(find ros_mscl)/launch/microstrain.launch">
+        <arg name="name"          value="cv5" />
+        <arg name="port"          value="$(optenv HERON_IMU_PORT /dev/microstrain)" /> <!-- TODO - verify the correct default -->
+        <arg name="imu_frame_id"  value="imu_link" />
+        <!-- TODO - double-check topic names -->
+        <remap from="cv5/data"    to="imu/raw_raw" />
+        <remap from="cv5/mag"     to="imu/mag" />
+      </include>
+    </group>
+    <group if="$(optenv HERON_IMU_UM6 0)">
+      <!-- older herons use the UM6 IMU -->
+      <group if="$(eval arg('namespace') == '')">
+       <node pkg="um6" type="um6_driver" name="um6_driver" output="screen">
+         <param name="tf_ned_to_enu" value="true"/>
+         <param name="/um6_driver/port" value="$(optenv HERON_IMU_UM6_PORT /dev/clearpath/imu)" />
+         <remap from="imu/data" to="imu/data_raw" />
+         <param name="lt_model" value="true" />
+         <param name="linear_acceleration_stdev" value="0.38" />
+         <param name="frame_id" value="imu_link" />
+       </node>
+      </group>
+
+      <group unless="$(eval arg('namespace') == '')">
+       <node pkg="um6" type="um6_driver" name="um6_driver" output="screen">
+         <param name="tf_ned_to_enu" value="true"/>
+         <param name="/um6_driver/port" value="$(optenv HERON_IMU_UM6_PORT /dev/clearpath/imu)" />
+         <remap from="imu/data" to="imu/data_raw" />
+         <param name="lt_model" value="true" />
+         <param name="linear_acceleration_stdev" value="0.38" />
+         <param name="frame_id" value="$(arg namespace)/imu_link" />
+       </node>
+      </group>
+    </group>
+
     <node pkg="imu_filter_madgwick" type="imu_filter_node" name="imu_filter_madgwick">
       <rosparam file="$(env HERON_MAG_CONFIG)" />
       <param name="~use_magnetic_field_msg" value="false" />

--- a/heron_base/package.xml
+++ b/heron_base/package.xml
@@ -22,9 +22,11 @@
   <run_depend>nmea_msgs</run_depend>
   <run_depend>nmea_comms</run_depend>
   <run_depend>nmea_navsat_driver</run_depend>
+  <run_depend>ros_mscl</run_depend>
   <run_depend>rosserial_python</run_depend>
   <run_depend>rosserial_server</run_depend>
   <run_depend>tf</run_depend>
+  <run_depend>um6</run_depend>
   <run_depend>heron_control</run_depend>
   <run_depend>wireless_watcher</run_depend>
   <run_depend>imu_filter_madgwick</run_depend>

--- a/heron_base/package.xml
+++ b/heron_base/package.xml
@@ -25,7 +25,6 @@
   <run_depend>rosserial_python</run_depend>
   <run_depend>rosserial_server</run_depend>
   <run_depend>tf</run_depend>
-  <run_depend>um6</run_depend>
   <run_depend>heron_control</run_depend>
   <run_depend>wireless_watcher</run_depend>
   <run_depend>imu_filter_madgwick</run_depend>

--- a/heron_bringup/scripts/compute_calibration
+++ b/heron_bringup/scripts/compute_calibration
@@ -25,7 +25,7 @@ try:
 except ImportError:
   pyplot = None
 
-parser = ArgumentParser(description='Process UM6 bag file for compass calibration. Pass a bag containing /imu/rpy and /imu/mag topics, with the UM6 compass facing upright, being slowly rotated in a clockwise direction for 30-120 seconds.')
+parser = ArgumentParser(description='Process IMU bag file for compass calibration. Pass a bag containing /imu/rpy and /imu/mag topics, with the IMU compass facing upright, being slowly rotated in a clockwise direction for 30-120 seconds.')
 parser.add_argument('bag', metavar='FILE', type=str, help='input bag file')
 parser.add_argument('outfile', metavar='OUTFILE', type=str, help='output yaml file',
                     nargs="?", default="/tmp/calibration.yaml")


### PR DESCRIPTION
Part 2 of purging references to UM6 from the repo, as per RPSW-661