### PR TITLE
Fix bugs related to the switch to CV5

### DIFF
--- a/heron_base/launch/base.launch
+++ b/heron_base/launch/base.launch
@@ -36,6 +36,7 @@
           <arg name="name"          value="cv5" />
           <arg name="port"          value="$(optenv HERON_IMU_PORT /dev/microstrain)" />
           <arg name="imu_frame_id"  value="imu_link" />
+          <arg name="use_enu_frame" value="true" />
         </include>
         <node pkg="topic_tools" type="relay" name="cv5_imu_relay" args="/cv5/imu/data /imu/data_raw" />
         <node pkg="topic_tools" type="relay" name="cv5_mag_relay" args="/cv5/mag /imu/mag" />
@@ -46,6 +47,7 @@
           <arg name="name"          value="cv5" />
           <arg name="port"          value="$(optenv HERON_IMU_PORT /dev/microstrain)" />
           <arg name="imu_frame_id"  value="$(arg namespace)/imu_link" />
+          <arg name="use_enu_frame" value="true" />
         </include>
         <node pkg="topic_tools" type="relay" name="cv5_imu_relay" args="$(arg namespace)/cv5/imu/data $(arg namespace)/imu/data_raw" />
         <node pkg="topic_tools" type="relay" name="cv5_mag_relay" args="$(arg namespace)/cv5/mag $(arg namespace)/imu/mag" />

--- a/heron_base/launch/base.launch
+++ b/heron_base/launch/base.launch
@@ -33,24 +33,24 @@
       <!-- newer herons use the microstrain CM5-25 IMU -->
       <group if="$(eval arg('namespace') == '')">
         <include file="$(find ros_mscl)/launch/microstrain.launch">
-          <arg name="name"          value="cv5" />
+          <arg name="name"          value="imu" />
           <arg name="port"          value="$(optenv HERON_IMU_PORT /dev/microstrain)" />
           <arg name="imu_frame_id"  value="imu_link" />
           <arg name="use_enu_frame" value="true" />
         </include>
-        <node pkg="topic_tools" type="relay" name="cv5_imu_relay" args="/cv5/imu/data /imu/data_raw" />
-        <node pkg="topic_tools" type="relay" name="cv5_mag_relay" args="/cv5/mag /imu/mag" />
+        <node pkg="topic_tools" type="relay" name="imu_data_relay" args="/imu/imu/data /imu/data_raw" />
+        <node pkg="topic_tools" type="relay" name="imu_mag_relay" args="/imu/mag /imu/mag" />
       </group>
 
       <group unless="$(eval arg('namespace') == '')">
         <include file="$(find ros_mscl)/launch/microstrain.launch">
-          <arg name="name"          value="cv5" />
+          <arg name="name"          value="imu" />
           <arg name="port"          value="$(optenv HERON_IMU_PORT /dev/microstrain)" />
           <arg name="imu_frame_id"  value="$(arg namespace)/imu_link" />
           <arg name="use_enu_frame" value="true" />
         </include>
-        <node pkg="topic_tools" type="relay" name="cv5_imu_relay" args="$(arg namespace)/cv5/imu/data $(arg namespace)/imu/data_raw" />
-        <node pkg="topic_tools" type="relay" name="cv5_mag_relay" args="$(arg namespace)/cv5/mag $(arg namespace)/imu/mag" />
+        <node pkg="topic_tools" type="relay" name="imu_data_relay" args="$(arg namespace)/imu/imu/data $(arg namespace)/imu/data_raw" />
+        <node pkg="topic_tools" type="relay" name="imu_mag_relay" args="$(arg namespace)/imu/mag $(arg namespace)/imu/mag" />
       </group>
     </group>
     <group if="$(optenv HERON_IMU_UM6 0)">

--- a/heron_base/launch/base.launch
+++ b/heron_base/launch/base.launch
@@ -32,23 +32,23 @@
     <group unless="$(optenv HERON_IMU_UM6 0)">
       <!-- newer herons use the microstrain CM5-25 IMU -->
       <group if="$(eval arg('namespace') == '')">
-        <include filename="$(find ros_mscl)/launch/microstrain.launch">
+        <include file="$(find ros_mscl)/launch/microstrain.launch">
           <arg name="name"          value="cv5" />
           <arg name="port"          value="$(optenv HERON_IMU_PORT /dev/microstrain)" />
           <arg name="imu_frame_id"  value="imu_link" />
-          <remap from="cv5/data"    to="imu/raw_raw" />
-          <remap from="cv5/mag"     to="imu/mag" />
         </include>
+        <node pkg="topic_tools" type="relay" name="cv5_imu_relay" args="/cv5/imu/data /imu/data_raw" />
+        <node pkg="topic_tools" type="relay" name="cv5_mag_relay" args="/cv5/mag /imu/mag" />
       </group>
 
       <group unless="$(eval arg('namespace') == '')">
-        <include filename="$(find ros_mscl)/launch/microstrain.launch">
+        <include file="$(find ros_mscl)/launch/microstrain.launch">
           <arg name="name"          value="cv5" />
           <arg name="port"          value="$(optenv HERON_IMU_PORT /dev/microstrain)" />
           <arg name="imu_frame_id"  value="$(arg namespace)/imu_link" />
-          <remap from="cv5/data"    to="imu/raw_raw" />
-          <remap from="cv5/mag"     to="imu/mag" />
         </include>
+        <node pkg="topic_tools" type="relay" name="cv5_imu_relay" args="$(arg namespace)/cv5/imu/data $(arg namespace)/imu/data_raw" />
+        <node pkg="topic_tools" type="relay" name="cv5_mag_relay" args="$(arg namespace)/cv5/mag $(arg namespace)/imu/mag" />
       </group>
     </group>
     <group if="$(optenv HERON_IMU_UM6 0)">

--- a/heron_base/package.xml
+++ b/heron_base/package.xml
@@ -31,6 +31,7 @@
   <run_depend>wireless_watcher</run_depend>
   <run_depend>imu_filter_madgwick</run_depend>
   <run_depend>python-pysnmp</run_depend>
+  <run_depend>topic_tools</run_depend>
 
   <export>
   </export>

--- a/heron_robot/package.xml
+++ b/heron_robot/package.xml
@@ -10,6 +10,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <run_depend>heron_base</run_depend>
   <run_depend>heron_bringup</run_depend>
   <run_depend>heron_controller</run_depend>
   <run_depend>heron_firmware</run_depend>


### PR DESCRIPTION
Fix a couple of bugs that somehow never got caught in the previous release, enable ENU mode for the CV5 IMU now that the ros_mscl driver supports it.