### PR TITLE
RPCUST-79 

### DIFF
--- a/heron_base/launch/base.launch
+++ b/heron_base/launch/base.launch
@@ -19,14 +19,20 @@
     <!-- TODO: Eliminate this by compiling the necessary message definitions into heron_base. -->
     <node pkg="rosserial_python" type="message_info_service.py" name="rosserial_message_info" />
 
-    <group if="$(optenv USE_SNMP_CHECK_NODE true)">
-      <node pkg="heron_base" type="snmp_lights.py" name="wifi_lights">
-        <param name="~ip_addr" value="$(optenv SNMP_IP 192.168.131.50)" />
-      </node>
+    <group if="$(optenv HERON_NO_WIRELESS false)">
+      <node ns="wireless" pkg="heron_base" name="no_wifi_lights" type="no_wireless_lights.py" respawn="true" />
     </group>
 
-    <group unless="$(optenv USE_SNMP_CHECK_NODE true)">
-      <node ns="wireless" pkg="wireless_watcher" name="wireless_watcher" type="watcher_node" respawn="true" />
+    <group unless="$(optenv HERON_NO_WIRELESS false)">
+      <group if="$(optenv USE_SNMP_CHECK_NODE true)">
+        <node pkg="heron_base" type="snmp_lights.py" name="wifi_lights">
+          <param name="~ip_addr" value="$(optenv SNMP_IP 192.168.131.50)" />
+        </node>
+      </group>
+
+      <group unless="$(optenv USE_SNMP_CHECK_NODE true)">
+        <node ns="wireless" pkg="wireless_watcher" name="wireless_watcher" type="watcher_node" respawn="true" />
+      </group>
     </group>
 
     <group unless="$(optenv HERON_IMU_UM6 0)">

--- a/heron_base/scripts/no_wireless_lights.py
+++ b/heron_base/scripts/no_wireless_lights.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD)
+#
+# @author    Chris Iverach-Brereton <civerachb@clearpathrobotics.com>
+# @copyright (c) 2021, Clearpath Robotics, Inc., All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+# the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+#   following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+#   following disclaimer in the documentation and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors may be used to endorse or
+#   promote products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+# TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import rospy
+from std_msgs.msg import Bool
+
+if __name__ == '__main__':
+    # Publish that the wireless is connected at 2Hz, to prevent the MCU from ever going into the slow-2 pulse mode
+    rospy.init_node('heron_no_wireless')
+    pub = rospy.Publisher('connected', Bool, queue_size=1)
+    rate = rospy.Rate(2)
+
+    msg = Bool()
+    msg.data = True
+
+    while not rospy.is_shutdown():
+        pub.publish(msg)
+        rate.sleep()


### PR DESCRIPTION
Add support for a HERON_NO_WIRELESS envar to completely disable checking for wireless connectivity; if enabled, just tell the MCU the wireless is fine and suppress the slow-2-pulse.